### PR TITLE
test(jwt): add unit tests and simplify extractRoles method in JwtService (#5)

### DIFF
--- a/src/main/java/com/example/restapi_java/service/auth/UserService.java
+++ b/src/main/java/com/example/restapi_java/service/auth/UserService.java
@@ -4,7 +4,6 @@ import com.example.restapi_java.dto.auth.AuthCredentials;
 import com.example.restapi_java.dto.auth.AuthResponse;
 import com.example.restapi_java.dto.auth.SignUp;
 import com.example.restapi_java.dto.roles.AssignRoleRequest;
-import com.example.restapi_java.dto.roles.RoleResponse;
 import com.example.restapi_java.exception.role.RoleNotFoundException;
 import com.example.restapi_java.exception.user.EmailAlreadyInUseException;
 import com.example.restapi_java.exception.user.InvalidCredentialsException;

--- a/src/main/java/com/example/restapi_java/service/management/RoleManagementService.java
+++ b/src/main/java/com/example/restapi_java/service/management/RoleManagementService.java
@@ -1,10 +1,10 @@
 package com.example.restapi_java.service.management;
 
+import com.example.restapi_java.model.Role;
 import com.example.restapi_java.service.auth.UserService;
 import com.example.restapi_java.service.role.RoleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import com.example.restapi_java.model.Role;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/restapi_java/service/security/JwtService.java
+++ b/src/main/java/com/example/restapi_java/service/security/JwtService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import java.security.Key;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -55,15 +54,11 @@ public class JwtService {
                 .parseClaimsJws(token)
                 .getBody();
 
-        Object raw = claims.get("roles");
+        Collection<?> rawRoles = (Collection<?>) claims.get("roles");
 
-        if (raw instanceof Collection<?> rolesCollection) {
-            return rolesCollection.stream()
-                    .filter(Objects::nonNull)
-                    .map(Object::toString)
-                    .collect(Collectors.toSet());
-        }
-        return Set.of();
+        return rawRoles.stream()
+                .map(Object::toString)
+                .collect(Collectors.toSet());
     }
 
     public boolean isTokenValid(String token) {

--- a/src/test/java/com/example/restapi_java/service/security/JwtServiceTest.java
+++ b/src/test/java/com/example/restapi_java/service/security/JwtServiceTest.java
@@ -1,0 +1,122 @@
+package com.example.restapi_java.service.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtServiceTest {
+
+    private JwtService jwtService;
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "SECRET_KEY", "OMBhwobThAOSDnqKbksOKekHNyeHnrHWqJXcM5Bv/Rs=");
+        jwtService.init();
+    }
+
+    @Test
+    void shouldGenerateValidToken_withSubjectAndRoles() {
+        String subject = "john@example.com";
+        Set<String> roles = Set.of("ROLE_ADMIN", "ROLE_USER");
+
+        String token = jwtService.generateToken(subject, roles);
+
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(
+                        "OMBhwobThAOSDnqKbksOKekHNyeHnrHWqJXcM5Bv/Rs=".getBytes()))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        assertEquals(subject, claims.getSubject());
+        assertEquals(roles, new HashSet<>((List<?>) claims.get("roles")));
+        assertNotNull(claims.getIssuedAt());
+        assertNotNull(claims.getExpiration());
+    }
+
+    @Test
+    void shouldExtractSubjectFromValidToken() {
+        String subject = "john@example.com";
+        String token = jwtService.generateToken(subject, Set.of("ROLE_USER"));
+
+        String extracted = jwtService.extractSubject(token);
+
+        assertEquals(subject, extracted);
+    }
+
+    @Test
+    void shouldExtractRolesFromValidToken() {
+        String subject = "john@example.com";
+        String token = jwtService.generateToken(subject, Set.of("ROLE_USER"));
+        Set<String> expectedRoles = Set.of("ROLE_USER");
+
+        Set<String> actualRoles = jwtService.extractRoles(token);
+
+        assertEquals(expectedRoles, actualRoles);
+    }
+
+    @Test
+    void shouldReturnTrue_whenTokenIsValidAndNotExpired() {
+        String subject = "john@example.com";
+        Set<String> roles = Set.of("ROLE_USER", "ROLE_ADMIN");
+        String token = jwtService.generateToken(subject, roles);
+
+        Boolean isValid = jwtService.isTokenValid(token);
+
+        assertEquals(true, isValid);
+    }
+
+    @Test
+    void shouldReturnFalse_whenTokenIsExpired() {
+        String subject = "john@example.com";
+        Set<String> roles = Set.of("ROLE_USER", "ROLE_ADMIN");
+
+        String expiredToken = Jwts.builder()
+                .setSubject(subject)
+                .claim("roles", roles)
+                .setIssuedAt(new Date(System.currentTimeMillis() - 2 * 60 * 60 * 1000))
+                .setExpiration(new Date(System.currentTimeMillis() - 60 * 60 * 1000))
+                .signWith(Keys.hmacShaKeyFor(
+                        "OMBhwobThAOSDnqKbksOKekHNyeHnrHWqJXcM5Bv/Rs=".getBytes()
+                ))
+                .compact();
+
+        Boolean isValid = jwtService.isTokenValid(expiredToken);
+
+        assertEquals(false, isValid);
+    }
+
+    @Test
+    void shouldReturnFalse_whenTokenIsNotValid() {
+        String subject = "john@example.com";
+        Set<String> roles = Set.of("ROLE_USER", "ROLE_ADMIN");
+
+        String invalidToken = Jwts.builder()
+                .setSubject(subject)
+                .claim("roles", roles)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 60 * 60 * 1000))
+                .signWith(Keys.hmacShaKeyFor(
+                        "INVALID_SECRET_MIN_256_BITS_REQUIRED".getBytes()
+                ))
+                .compact();
+
+        Boolean isValid = jwtService.isTokenValid(invalidToken);
+        assertEquals(false, isValid);
+    }
+}


### PR DESCRIPTION
Added unit tests covering token generation, extraction of subject and roles, and validation of token expiration. Refactored extractRoles method by removing unnecessary instanceof check and assuming roles are always passed as a Set during token creation.